### PR TITLE
Add option to disable config file/license key args

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -14,13 +14,20 @@ if ! find . -mindepth 1 | read; then
   echo -e "----------------------------------------------\n"
 fi
 
-if [ -z "${LICENCE_KEY}" ]; then
-  echo "Licence key not found in environment, please create one at https://keymaster.fivem.net!"
-  exit 1
+CONFIG_ARGS=
+if [ -z "${NO_DEFAULT_CONFIG}" ]; then
+  CONFIG_ARGS="$CONFIG_ARGS +exec /config/server.cfg"
 fi
+if [ -z "${NO_LICENSE_KEY}" ]; then
+  if [ -z "${LICENCE_KEY}" ]; then
+    echo "Licence key not found in environment, please create one at https://keymaster.fivem.net!"
+    exit 1
+  fi
+  CONFIG_ARGS="$CONFIG_ARGS +set sv_licenseKey ${LICENCE_KEY}"
+fi
+
 
 exec /opt/cfx-server/FXServer \
        +set citizen_dir /opt/cfx-server/citizen/ \
-       +exec /config/server.cfg \
-       +set sv_licenseKey ${LICENCE_KEY} \
+       $CONFIG_ARGS \
        $@


### PR DESCRIPTION
These variables can be set to disable the default behaviour of passing
the default config file, and the license key to the fxserver process.

$NO_DEFAULT_CONFIG disables the `+exec /config/server.cfg` options

$NO_LICENSE_KEY disables passing the license key to fxserver, in case
it's set within the config file, or you want the program to exit
exceptionally, 🤷 we don't judge.

Signed-off-by: Joe Groocock <me@frebib.net>