### PR TITLE
Fix licence typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This docker image allows you to run a server for FiveM, a modded GTA multiplayer
 Upon first run, the configuration is generated in the host mount for the `/config` directory.
 The container should be stopped so fivem can be configured to the user requirements in the `server.cfg`.
 
-## Licence Key
+## License Key
 
-A freely obtained licence key is required to use this server, which should be declared as `$LICENCE_KEY`. A tutorial on how to obtain a licence key can be found [here](https://forum.fivem.net/t/explained-how-to-make-add-a-server-key/56120)
+A freely obtained license key is required to use this server, which should be declared as `$LICENSE_KEY`. A tutorial on how to obtain a license key can be found [here](https://forum.fivem.net/t/explained-how-to-make-add-a-server-key/56120)
 
 ## Usage
 
@@ -27,7 +27,7 @@ Use the docker-compose script provided if you wish to run a couchdb server with 
 docker run -d \
   --name FiveM \
   --restart=on-failure \
-  -e LICENCE_KEY=<your-license-here>
+  -e LICENSE_KEY=<your-license-here>
   -p 30120:30120 \
   -p 30120:30120/udp \
   -v /volumes/fivem:/config \
@@ -40,5 +40,5 @@ See [issue #3](https://github.com/spritsail/fivem/issues/3)
 
 ### Environment Varibles
 
-- `LICENSE_KEY` - This is a required variable for the licence key needed to start the server.
+- `LICENSE_KEY` - This is a required variable for the license key needed to start the server.
 - `RCON_PASSWORD` - A password to use for the RCON functionality of the fxserver. If not specified, a random 16 character password is assigned. This is only used upon creation of the default configs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ services:
       - "30120:30120"
       - "30120:30120/udp"
     environment:
-      LICENCE_KEY: "license-key-here"
+      LICENSE_KEY: "license-key-here"

--- a/entrypoint
+++ b/entrypoint
@@ -19,11 +19,11 @@ if [ -z "${NO_DEFAULT_CONFIG}" ]; then
   CONFIG_ARGS="$CONFIG_ARGS +exec /config/server.cfg"
 fi
 if [ -z "${NO_LICENSE_KEY}" ]; then
-  if [ -z "${LICENCE_KEY}" ]; then
-    echo "Licence key not found in environment, please create one at https://keymaster.fivem.net!"
+  if [ -z "${LICENSE_KEY}" ]; then
+    echo "License key not found in environment, please create one at https://keymaster.fivem.net!"
     exit 1
   fi
-  CONFIG_ARGS="$CONFIG_ARGS +set sv_licenseKey ${LICENCE_KEY}"
+  CONFIG_ARGS="$CONFIG_ARGS +set sv_licenseKey ${LICENSE_KEY}"
 fi
 
 


### PR DESCRIPTION
At various places in the repo the typo licen***c***e pops up which makes initial configuration confusing since the typo does not appear in the README.