### PR TITLE
Nginx-Proxy support for txAdmin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ COPY --from=builder /output/ /
 
 WORKDIR /config
 EXPOSE 30120
+# Required for NGINX-Proxy
+EXPOSE 40120
 
 # Default to an empty CMD, so we can use it to add seperate args to the binary
 CMD [""]


### PR DESCRIPTION
Hi,

The port required for txAdmin need's to be exposed in the Dockerfile, so that you can connect it with nginx-proxy.

Thank you,
Mike