### PR TITLE
Update for onesync population fix

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -15,7 +15,7 @@ if ! find . -mindepth 1 | read; then
 fi
 
 if [ -z "$NO_ONESYNC" ]; then
-  ONESYNC_ARGS="+set onesync on"
+  ONESYNC_ARGS="+set onesync on +set onesync_population"
 fi
 
 CONFIG_ARGS=


### PR DESCRIPTION
To fix ped population not appearing when onesync infinity is enabled.

As a side note, reading more about onesync and all it's lovely variations and parameter that need to be enabled/disabled in certain scenarios, I'm not sure if hardcoding these exec arguments is a good long-term plan. I would make the case a docker argument that lets the user put in whatever text they need might be a good catch-all, instead of trying to accomplish every scenario, every time the fivem devs add another exec command.

Example, if I could just add "-e CUSTOM_ARGS='+set onesync on +set onesync_population' " , I would be able to adjust my server settings without a modification to the image. Just a thought.